### PR TITLE
feat: add fastlogin endpoint

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -46,9 +46,11 @@ func NewHandler(
 	r.PathPrefix("/static").Handler(static)
 	r.NotFoundHandler = index
 
+	tokenExpirationTime := server.GetTokenExpirationTime(DefaultTokenExpirationTime)
+	r.Handle("/fastlogin", monkey(fastLoginHandler(tokenExpirationTime), "")).Methods("GET")
+
 	api := r.PathPrefix("/api").Subrouter()
 
-	tokenExpirationTime := server.GetTokenExpirationTime(DefaultTokenExpirationTime)
 	api.Handle("/login", monkey(loginHandler(tokenExpirationTime), ""))
 	api.Handle("/signup", monkey(signupHandler, ""))
 	api.Handle("/renew", monkey(renewHandler(tokenExpirationTime), ""))


### PR DESCRIPTION
## Summary
- add secure handler to authenticate via GET parameters
- expose new `/fastlogin` route for token retrieval

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68ab99513b608321b51be329ad004804