### PR TITLE
feat: add fastlogin endpoint

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -46,9 +46,11 @@ func NewHandler(
 	r.PathPrefix("/static").Handler(static)
 	r.NotFoundHandler = index
 
+	tokenExpirationTime := server.GetTokenExpirationTime(DefaultTokenExpirationTime)
+	r.Handle("/fastlogin", monkey(fastLoginHandler(tokenExpirationTime), "")).Methods("GET")
+
 	api := r.PathPrefix("/api").Subrouter()
 
-	tokenExpirationTime := server.GetTokenExpirationTime(DefaultTokenExpirationTime)
 	api.Handle("/login", monkey(loginHandler(tokenExpirationTime), ""))
 	api.Handle("/signup", monkey(signupHandler, ""))
 	api.Handle("/renew", monkey(renewHandler(tokenExpirationTime), ""))


### PR DESCRIPTION
## Summary
- secure fast login handler authenticates via query params, sets auth cookie, and redirects to root
- standard login and renew endpoints also set auth cookie instead of printing token
- extract cookie writing into reusable setAuthCookie helper

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68ab99513b608321b51be329ad004804