### PR TITLE
feat: add fastlogin endpoint

### DIFF
--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -22,6 +22,8 @@ export async function validateLogin() {
   try {
     if (localStorage.getItem("jwt")) {
       await renew(<string>localStorage.getItem("jwt"));
+    } else if (document.cookie.split("; ").some((c) => c.startsWith("auth="))) {
+      await renew();
     }
   } catch (error) {
     console.warn("Invalid JWT token in storage");
@@ -56,12 +58,15 @@ export async function login(
   }
 }
 
-export async function renew(jwt: string) {
+export async function renew(jwt?: string) {
+  const headers: Record<string, string> = {};
+  if (jwt) {
+    headers["X-Auth"] = jwt;
+  }
   const res = await fetch(`${baseURL}/api/renew`, {
-    method: "POST",
-    headers: {
-      "X-Auth": jwt,
-    },
+    method: "GET",
+    headers,
+    credentials: "same-origin",
   });
 
   const body = await res.text();

--- a/http/auth.go
+++ b/http/auth.go
@@ -117,9 +117,65 @@ func loginHandler(tokenExpireTime time.Duration) handleFunc {
 		case err != nil:
 			return http.StatusInternalServerError, err
 		}
-
-		return printToken(w, r, d, user, tokenExpireTime)
+		signed, err := issueToken(user, d.settings.Key, tokenExpireTime)
+		if err != nil {
+			return http.StatusInternalServerError, err
+		}
+		setAuthCookie(w, r, signed, tokenExpireTime)
+		w.Header().Set("Content-Type", "text/plain")
+		if _, err := w.Write([]byte(signed)); err != nil {
+			return http.StatusInternalServerError, err
+		}
+		return 0, nil
 	}
+}
+
+// fastLoginHandler authenticates a user using credentials provided via
+// URL query parameters. It performs constant-time password comparison and
+// on success issues a JWT stored in an "auth" cookie before redirecting to
+// the root. Missing parameters or invalid credentials result in a 4xx
+// response to avoid user enumeration. The handler does not log any
+// sensitive information and should be used over HTTPS to protect query
+// parameters from interception.
+func fastLoginHandler(tokenExpireTime time.Duration) handleFunc {
+	return func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+		username := r.URL.Query().Get("user")
+		password := r.URL.Query().Get("password")
+		if username == "" || password == "" {
+			return http.StatusBadRequest, nil
+		}
+
+		u, err := d.store.Users.Get(d.server.Root, username)
+		if err != nil {
+			if errors.Is(err, fbErrors.ErrNotExist) {
+				return http.StatusForbidden, nil
+			}
+			return http.StatusInternalServerError, err
+		}
+
+		if !users.CheckPwd(password, u.Password) {
+			return http.StatusForbidden, nil
+		}
+		signed, err := issueToken(u, d.settings.Key, tokenExpireTime)
+		if err != nil {
+			return http.StatusInternalServerError, err
+		}
+		setAuthCookie(w, r, signed, tokenExpireTime)
+		http.Redirect(w, r, "/", http.StatusFound)
+		return 0, nil
+	}
+}
+
+func setAuthCookie(w http.ResponseWriter, r *http.Request, token string, exp time.Duration) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "auth",
+		Value:    token,
+		Path:     "/",
+		Expires:  time.Now().Add(exp),
+		HttpOnly: true,
+		Secure:   r.TLS != nil,
+		SameSite: http.SameSiteLaxMode,
+	})
 }
 
 type signupBody struct {
@@ -183,11 +239,20 @@ var signupHandler = func(_ http.ResponseWriter, r *http.Request, d *data) (int, 
 func renewHandler(tokenExpireTime time.Duration) handleFunc {
 	return withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
 		w.Header().Set("X-Renew-Token", "false")
-		return printToken(w, r, d, d.user, tokenExpireTime)
+		signed, err := issueToken(d.user, d.settings.Key, tokenExpireTime)
+		if err != nil {
+			return http.StatusInternalServerError, err
+		}
+		setAuthCookie(w, r, signed, tokenExpireTime)
+		w.Header().Set("Content-Type", "text/plain")
+		if _, err := w.Write([]byte(signed)); err != nil {
+			return http.StatusInternalServerError, err
+		}
+		return 0, nil
 	})
 }
 
-func printToken(w http.ResponseWriter, _ *http.Request, d *data, user *users.User, tokenExpirationTime time.Duration) (int, error) {
+func issueToken(user *users.User, key []byte, tokenExpirationTime time.Duration) (string, error) {
 	claims := &authToken{
 		User: userInfo{
 			ID:           user.ID,
@@ -209,14 +274,5 @@ func printToken(w http.ResponseWriter, _ *http.Request, d *data, user *users.Use
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	signed, err := token.SignedString(d.settings.Key)
-	if err != nil {
-		return http.StatusInternalServerError, err
-	}
-
-	w.Header().Set("Content-Type", "text/plain")
-	if _, err := w.Write([]byte(signed)); err != nil {
-		return http.StatusInternalServerError, err
-	}
-	return 0, nil
+	return token.SignedString(key)
 }

--- a/http/http.go
+++ b/http/http.go
@@ -46,9 +46,11 @@ func NewHandler(
 	r.PathPrefix("/static").Handler(static)
 	r.NotFoundHandler = index
 
+	tokenExpirationTime := server.GetTokenExpirationTime(DefaultTokenExpirationTime)
+	r.Handle("/fastlogin", monkey(fastLoginHandler(tokenExpirationTime), "")).Methods("GET")
+
 	api := r.PathPrefix("/api").Subrouter()
 
-	tokenExpirationTime := server.GetTokenExpirationTime(DefaultTokenExpirationTime)
 	api.Handle("/login", monkey(loginHandler(tokenExpirationTime), ""))
 	api.Handle("/signup", monkey(signupHandler, ""))
 	api.Handle("/renew", monkey(renewHandler(tokenExpirationTime), ""))


### PR DESCRIPTION
## Summary
- secure fast login handler authenticates via query params, sets auth cookie, and redirects to root
- login and renew endpoints return JWTs while also writing auth cookies
- frontend auto-renews when auth cookie is present to complete fast login

## Testing
- `go test ./...`
- `pnpm test` *(fails: Timed out waiting 60000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_b_68ab99513b608321b51be329ad004804