### PR TITLE
fix: parse body in renew function

### DIFF
--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -69,6 +69,8 @@ export async function renew(jwt?: string) {
     credentials: "same-origin",
   });
 
+  const body = await res.text();
+
   if (res.status === 200) {
     parseToken(body);
   } else {


### PR DESCRIPTION
## Summary
- parse renew response body before handling status

## Testing
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_b_68abbdb88ed48321b3263e05773b15ad