### PR TITLE
Fix fast login and renew authentication flow

### DIFF
--- a/http/auth.go
+++ b/http/auth.go
@@ -154,7 +154,12 @@ func fastLoginHandler(tokenExpireTime time.Duration) handleFunc {
 			return http.StatusInternalServerError, err
 		}
 		setAuthCookie(w, r, signed, tokenExpireTime)
-		w.WriteHeader(http.StatusNoContent)
+
+		redirect := r.URL.Query().Get("redirect")
+		if redirect == "" {
+			redirect = "/"
+		}
+		http.Redirect(w, r, redirect, http.StatusFound)
 		return 0, nil
 	}
 }
@@ -237,7 +242,10 @@ func renewHandler(tokenExpireTime time.Duration) handleFunc {
 			return http.StatusInternalServerError, err
 		}
 		setAuthCookie(w, r, signed, tokenExpireTime)
-		w.WriteHeader(http.StatusNoContent)
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		if _, err := w.Write([]byte(signed)); err != nil {
+			return http.StatusInternalServerError, err
+		}
 		return 0, nil
 	})
 }


### PR DESCRIPTION
## Summary
- redirect fast login to requested path after setting auth cookie
- return token from renew endpoint so client validates session

## Testing
- `go test ./http`


------
https://chatgpt.com/codex/tasks/task_b_68abc6d2ab008321ae9cdbcadf345d02