### PR TITLE
Fix login endpoint returning 404

### DIFF
--- a/http/auth.go
+++ b/http/auth.go
@@ -122,8 +122,13 @@ func loginHandler(tokenExpireTime time.Duration) handleFunc {
 			return http.StatusInternalServerError, err
 		}
 		setAuthCookie(w, r, signed, tokenExpireTime)
-		w.WriteHeader(http.StatusNoContent)
-		return 0, nil
+
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		if _, err = w.Write([]byte(signed)); err != nil {
+			return http.StatusInternalServerError, err
+		}
+
+		return http.StatusOK, nil
 	}
 }
 

--- a/http/http.go
+++ b/http/http.go
@@ -46,8 +46,10 @@ func NewHandler(
 	r.PathPrefix("/static").Handler(static)
 	r.NotFoundHandler = index
 
-tokenExpirationTime := server.GetTokenExpirationTime(DefaultTokenExpirationTime)
-	r.Handle("/fastlogin", monkey(fastLoginHandler(tokenExpirationTime), "")).Methods("GET")
+	tokenExpirationTime := server.GetTokenExpirationTime(DefaultTokenExpirationTime)
+	fast := monkey(fastLoginHandler(tokenExpirationTime), "")
+	r.Handle("/fastlogin", fast).Methods("GET")
+	r.Handle("/fastlogin/", fast).Methods("GET")
 
 	api := r.PathPrefix("/api").Subrouter()
 


### PR DESCRIPTION
## Summary
- return JWT and HTTP 200 from login endpoint
- expose fastlogin route with and without trailing slash

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68ac8ec904608321b7eef6a5eddeabe6